### PR TITLE
Add tracking pixel

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,38 @@
 # Guardian visuals static uploader
 Upload static assets to S3.
 
-A zip file can be uploaded and the contents of which will be servered from a
+A zip file can be uploaded and the contents of which will be served from a
 new folder on S3.
 
 ## Setup
 You'll need `nodejs` and `npm`.
 
+To run locally:
 ```bash
-nmp install
-node s3-upload-server.js
+npm install
+npm run dev
 
 ```
+This will serve the app locally at http://0.0.0.0:4004/
 
 As this will be running as a service it's advised to use process manager 
 such as [forever](https://github.com/foreverjs/forever) or 
 [pm2](https://github.com/Unitech/pm2)
 
+## Deployment
+This app is deployed manually to an EC2 instance in our `interactives` account. The Interactives team can share the location of the instance with you.
+
+In order to deploy a new version, first merge your changes to the `master` branch in GitHub.
+
+Next, ssh onto the EC2 instance and run:
+
+```bash
+cd interactive-static-uploader
+git pull
+sudo supervisorctl restart staticuploader
+```
+
+In order to ssh onto the instance, someone with pre-existing access will need to add your ssh key to the instance. You'll also need to be working on an IP permitted by the security group (the office is permitted, for example).
 
 ## Todo
 - [ ] Reduce code clutter

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -9,6 +9,16 @@
         <link type="text/css" rel="stylesheet" href="css/fonts.css" />
         <link type="text/css" rel="stylesheet" href="css/styles.css" />
         <title>Guardian - Visuals static uploader</title>
+        <script>
+            const getTrackingPixel = () => {
+                const isProd = window.location.hostname === "visuals.gutools.co.uk";
+                const stage = isProd ? "PROD" : "CODE";
+                const trackingUrl = isProd ? "user-telemetry.gutools.co.uk" : "user-telemetry.local.dev-gutools.co.uk";
+                const pixel = `<img height=0 width=0 src="${trackingUrl}?app=interactive-static-uploader&stage=${stage}&path=/">`
+                return pixel;
+            };
+            document.getElementsByTagName("head")[0].innerHTML += getTrackingPixel(); 
+        </script>
     </head>
     <body>
         <header id="header">

--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -13,7 +13,7 @@
             const getTrackingPixel = () => {
                 const isProd = window.location.hostname === "visuals.gutools.co.uk";
                 const stage = isProd ? "PROD" : "CODE";
-                const trackingUrl = isProd ? "user-telemetry.gutools.co.uk" : "user-telemetry.local.dev-gutools.co.uk";
+                const trackingUrl = isProd ? "https://user-telemetry.gutools.co.uk" : "https://user-telemetry.local.dev-gutools.co.uk";
                 const pixel = `<img height=0 width=0 src="${trackingUrl}?app=interactive-static-uploader&stage=${stage}&path=/">`
                 return pixel;
             };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR adds a tracking pixel to the [interactive-static-uploader](https://visuals.gutools.co.uk/uploader/), collecting usage data via the [editorial-tools-user-telemetry-service](https://github.com/guardian/editorial-tools-user-telemetry-service/pull/52), supporting the Workflow and Collaboration team in conducting an audit of internal tools across the estate.

Information on how to run the app was very sparse, so I've update information on how to run the app locally and how to deploy it (it's very non-standard compared to our other apps).

My method for inserting the `img` tag is a bit inelegant, via an inline script tag, but I want to interact with the code as little as possible because it uses paradigms I'm not familiar with (e.g. koa, mustache, bower) and I don't want to risk breaking anything, given the lack of tests, lack of CODE environment, and the need for a manual deploy via sshing onto an instance.

## How to test

Run the app locally using:

```bash
npm install
npm run dev
```

Then load the application at http://0.0.0.0:4004/

The instance currently uses node `v6.9.2` (which is very old) - but this isn't documented anywhere so I'm reluctant to add a `.nvmrc` file. I used 6.9.2 via:

```bash
fnm install 6.9.2
fnm use 6.9.2
```

Can you see the pixel inside the `<head>` tag, using local telemetry service values? Does the network tab show that the page has attempted to load the pixel?

## How can we measure success?

One we merge to PROD, usage will start showing up in our [Tool Audit dashboard.](https://metrics.gutools.co.uk/d/aegzv59r9eghsd/tool-audit?orgId=1&var-domain=webstories.theguardian.com&var-path=All&var-interval=6h&var-chosen_apps=All)