### PR TITLE
Use correct url for tracking pixel

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -14,7 +14,7 @@
                 const isProd = window.location.hostname === "visuals.gutools.co.uk";
                 const stage = isProd ? "PROD" : "CODE";
                 const trackingUrl = isProd ? "https://user-telemetry.gutools.co.uk" : "https://user-telemetry.local.dev-gutools.co.uk";
-                const pixel = `<img height=0 width=0 src="${trackingUrl}?app=interactive-static-uploader&stage=${stage}&path=/">`
+                const pixel = `<img height=0 width=0 src="${trackingUrl}/tracking-pixel?app=interactive-static-uploader&stage=${stage}&path=/">`
                 return pixel;
             };
             document.getElementsByTagName("head")[0].innerHTML += getTrackingPixel(); 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

I managed to use the wrong URL on the previous PR for our tracking pixel.

This PR fixes it.