### PR TITLE
Include dynamic pathname in pixel tracking

### DIFF
--- a/src/templates/base.html
+++ b/src/templates/base.html
@@ -14,7 +14,8 @@
                 const isProd = window.location.hostname === "visuals.gutools.co.uk";
                 const stage = isProd ? "PROD" : "CODE";
                 const trackingUrl = isProd ? "https://user-telemetry.gutools.co.uk" : "https://user-telemetry.local.dev-gutools.co.uk";
-                const pixel = `<img height=0 width=0 src="${trackingUrl}/guardian-tool-accessed?app=interactive-static-uploader&stage=${stage}&path=/">`
+                const path = window.location.pathname;
+                const pixel = `<img height=0 width=0 src="${trackingUrl}/guardian-tool-accessed?app=interactive-static-uploader&stage=${stage}&path=${path}">`
                 return pixel;
             };
             document.getElementsByTagName("head")[0].innerHTML += getTrackingPixel(); 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Include the page path in pixel tracking, based on the window's path.

This will help us track usage of the tool properly in our Grafana dashboard - currently it is bundled alongside traffic on `visuals.gutools.co.uk/` (the visuals intraweb).